### PR TITLE
Pass explicit query to next_tag()

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -82,7 +82,12 @@ function odid_visit_tag( OD_Tag_Visitor_Context $context ): void {
 			return;
 		}
 
-		while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+		// As of 1.0.0-beta3, next_tag() allows $query and is beginning to migrate to skip tag closers by default.
+		// In versions prior to this, the method always visited closers and passing a $query actually threw an exception.
+		$tag_query = version_compare( OPTIMIZATION_DETECTIVE_VERSION, '1.0.0-beta3', '>=' )
+			? array( 'tag_closers' => 'visit' )
+			: null;
+		while ( $processor->next_tag( $tag_query ) ) {
 			if ( $processor->get_tag() === 'SOURCE' ) { // @phpstan-ignore identical.alwaysFalse
 				$src = $processor->get_attribute( 'src' );
 				if ( is_string( $src ) ) {

--- a/helper.php
+++ b/helper.php
@@ -82,7 +82,7 @@ function odid_visit_tag( OD_Tag_Visitor_Context $context ): void {
 			return;
 		}
 
-		while ( $processor->next_tag() ) {
+		while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 			if ( $processor->get_tag() === 'SOURCE' ) { // @phpstan-ignore identical.alwaysFalse
 				$src = $processor->get_attribute( 'src' );
 				if ( is_string( $src ) ) {

--- a/od-intrinsic-dimensions.php
+++ b/od-intrinsic-dimensions.php
@@ -31,10 +31,6 @@ add_action(
 	static function ( string $od_version ): void {
 		if (
 			version_compare( (string) strtok( $od_version, '-' ), '1.0.0', '<' )
-			||
-			'1.0.0-beta1' === $od_version
-			||
-			'1.0.0-beta2' === $od_version
 		) {
 			return;
 		}

--- a/od-intrinsic-dimensions.php
+++ b/od-intrinsic-dimensions.php
@@ -31,6 +31,10 @@ add_action(
 	static function ( string $od_version ): void {
 		if (
 			version_compare( (string) strtok( $od_version, '-' ), '1.0.0', '<' )
+			||
+			'1.0.0-beta1' === $od_version
+			||
+			'1.0.0-beta2' === $od_version
 		) {
 			return;
 		}


### PR DESCRIPTION
Depends on https://github.com/WordPress/performance/pull/1872

This will avoid the migration warning being emitted.